### PR TITLE
check for undefined target

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,14 +29,15 @@ export default (Target, supportedEvents = ['mousedown']) => {
                 isOutside,
                 target,
                 targetElement;
-
             target = this.refs.target;
             targetElement = ReactDOM.findDOMNode(target);
-            isInside = targetElement.contains(event.target) || targetElement === event.target;
-            isOutside = !isInside;
+            if(targetElement != undefined) {
+              isInside = targetElement.contains(event.target) || targetElement === event.target;
+              isOutside = !isInside;
 
-            if (isOutside) {
-                target.onOutsideEvent(event);
+              if (isOutside) {
+                  target.onOutsideEvent(event);
+              }
             }
         };
 


### PR DESCRIPTION
PR for #4 
Check if the target element is present on the page to prevent error.
Wrapped the inside/outside check and handler call in:
```javascript
if(targetElement != undefined) {
//...
}
```